### PR TITLE
Fix dependancies on libssl-dev to compile x86/x86_64 linux kernel + cleaning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update -y && \
 apt-get -y install build-essential git libncurses5-dev qt5-default qttools5-dev-tools \
 mercurial libdbus-glib-1-dev texinfo zip openssh-client \
 software-properties-common wget cpio bc locales rsync imagemagick \
-nano vim automake mtools dosfstools subversion openjdk-8-jdk
+nano vim automake mtools dosfstools subversion openjdk-8-jdk libssl-dev && \
+rm -rf /var/lib/apt/lists/*
 
 # Set the locale needed by toolchain
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen


### PR DESCRIPTION
Building the x86 and x86_64 linux kernels depends on libssl-dev (or got an error).
This patch add libssl-dev in image.

It also cleans the APT repositories cache to save some MB on the image size (which doesn't need this cache).